### PR TITLE
bug: remove deprectaed np.complex_ type

### DIFF
--- a/numpyencoder/numpyencoder.py
+++ b/numpyencoder/numpyencoder.py
@@ -28,7 +28,7 @@ class NumpyEncoder(json.JSONEncoder):
         elif isinstance(obj, (np.float16, np.float32, np.float64)):
             return float(obj)
 
-        elif isinstance(obj, (np.complex_, np.complex64, np.complex128)):
+        elif isinstance(obj, (np.complex64, np.complex128)):
             return {"real": obj.real, "imag": obj.imag}
 
         elif isinstance(obj, (np.ndarray,)):


### PR DESCRIPTION
Encountered a deprecation error for `np.complex_` type...

```
=========================================================================== FAILURES ===========================================================================
______________________________________________________________________ test_array_of_int _______________________________________________________________________

    def test_array_of_int():
        import json
        import numpy as np
        from numpyencoder import NumpyEncoder
    
        numpy_data = np.array([np.int64(0), np.int32(1), 2, 3])
        baseline_data = [0, 1, 2, 3]
    
>       j_np = json.dumps(
            numpy_data,
            sort_keys=True,
            separators=(", ", ": "),
            ensure_ascii=False,
            cls=NumpyEncoder,
        )

tests/test_example.py:9: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/lib/python3.11/json/__init__.py:238: in dumps
    **kw).encode(obj)
/usr/lib/python3.11/json/encoder.py:200: in encode
    chunks = self.iterencode(o, _one_shot=True)
/usr/lib/python3.11/json/encoder.py:258: in iterencode
    return _iterencode(o, 0)
/home/neil/.virtualenvs/topostats-afmreader/lib/python3.11/site-packages/numpyencoder/numpyencoder.py:31: in default
    elif isinstance(obj, (np.complex_, np.complex64, np.complex128)):
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

attr = 'complex_'

    def __getattr__(attr):
        # Warn for expired attributes
        import warnings
    
        if attr == "linalg":
            import numpy.linalg as linalg
            return linalg
        elif attr == "fft":
            import numpy.fft as fft
            return fft
        elif attr == "dtypes":
            import numpy.dtypes as dtypes
            return dtypes
        elif attr == "random":
            import numpy.random as random
            return random
        elif attr == "polynomial":
            import numpy.polynomial as polynomial
            return polynomial
        elif attr == "ma":
            import numpy.ma as ma
            return ma
        elif attr == "ctypeslib":
            import numpy.ctypeslib as ctypeslib
            return ctypeslib
        elif attr == "exceptions":
            import numpy.exceptions as exceptions
            return exceptions
        elif attr == "testing":
            import numpy.testing as testing
            return testing
        elif attr == "matlib":
            import numpy.matlib as matlib
            return matlib
        elif attr == "f2py":
            import numpy.f2py as f2py
            return f2py
        elif attr == "typing":
            import numpy.typing as typing
            return typing
        elif attr == "rec":
            import numpy.rec as rec
            return rec
        elif attr == "char":
            import numpy.char as char
            return char
        elif attr == "array_api":
            raise AttributeError("`numpy.array_api` is not available from "
                                 "numpy 2.0 onwards")
        elif attr == "core":
            import numpy.core as core
            return core
        elif attr == "strings":
            import numpy.strings as strings
            return strings
        elif attr == "distutils":
            if 'distutils' in __numpy_submodules__:
                import numpy.distutils as distutils
                return distutils
            else:
                raise AttributeError("`numpy.distutils` is not available from "
                                     "Python 3.12 onwards")
    
        if attr in __future_scalars__:
            # And future warnings for those that will change, but also give
            # the AttributeError
            warnings.warn(
                f"In the future `np.{attr}` will be defined as the "
                "corresponding NumPy scalar.", FutureWarning, stacklevel=2)
    
        if attr in __former_attrs__:
            raise AttributeError(__former_attrs__[attr])
    
        if attr in __expired_attributes__:
>           raise AttributeError(
                f"`np.{attr}` was removed in the NumPy 2.0 release. "
                f"{__expired_attributes__[attr]}"
            )
E           AttributeError: `np.complex_` was removed in the NumPy 2.0 release. Use `np.complex128` instead.

/home/neil/.virtualenvs/topostats-afmreader/lib/python3.11/site-packages/numpy/__init__.py:397: AttributeError
```

As `np.complex128` is already one of the possible instance types I have removed `np.complex_` from the tuple of possible types.